### PR TITLE
Redirect to new profile path after sign up and show a message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
 
   # TODO: logged out users don't count notifications
   before_action :notification_count
-  
+
   private
 
   def notification_count

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
 
   # TODO: logged out users don't count notifications
   before_action :notification_count
-
+  
   private
 
   def notification_count

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,7 @@
+class RegistrationsController < Devise::RegistrationsController
+  protected
+  
+  def after_sign_up_path_for(user)
+    new_profile_path
+  end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -4,7 +4,7 @@
 class RegistrationsController < Devise::RegistrationsController
   protected
   
-  def after_sign_up_path_for(user)
+  def after_sign_up_path_for(_resource)
     new_profile_path
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-#Define redirect route after registration for devise
+# Define redirect route after registration for devise
 class RegistrationsController < Devise::RegistrationsController
   protected
-  
+
   def after_sign_up_path_for(_resource)
     new_profile_path
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+#Define redirect route after registration for devise
 class RegistrationsController < Devise::RegistrationsController
   protected
   

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -38,7 +38,7 @@ en:
       updated_not_active: "Your password has been changed successfully."
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
-      signed_up: "Welcome! You have signed up successfully."
+      signed_up: "Welcome! You have signed up successfully. Fill out your profile to start attending events!"
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 Rails.application.routes.draw do
   root "support#about"
 
-  devise_for :users
+  devise_for :users, controllers: { registrations: "registrations" }
 
   resources :events
   resources :event_attendees


### PR DESCRIPTION
## Description of Feature or Issue
closes #44 

User is redirected to the new profile path after sign up and asked to create a profile in the welcome message. I think this makes the most sense in terms of the registration flow, instead of waiting for an error message or auto-filling the profile. Had to create a new registrations controller to change the redirect path for Devise.

## Checklist
- [ ] Added/changed specs for the changes made
- [x] Is the linting build successful?
- [x] Is the test build successful?

## User-Facing Changes
<!-- If there have been user facing change please include screenshots -->
![Screenshot 2024-01-15 at 11 50 03 AM](https://github.com/ChaelCodes/HallwayTracks/assets/57076268/64949cd8-64d0-4922-a8b9-6c4e4c29ec5c)
