### PR TITLE
Update Event Page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,8 +81,11 @@ To run rubocop:\
 
 To reset the database with the seed data:
 1. (If server was running) Shut down the web server: `docker compose stop web`
-2. Reset the DB: `docker-compose run web bundle exec rake db:reset`
+2. Reset the DB: `docker compose run web bundle exec rake db:reset`
 3. (If server was running) Bring the web server back up: `docker compose start web`
+
+To populate the existing database with seed data (idempotent):\
+`docker compose run web bundle exec rake db:seed`
 
 ## Updating Node Modules
 You'll have to update your node_modules folder if you see a message similar to the one below.

--- a/app/controllers/event_attendees_controller.rb
+++ b/app/controllers/event_attendees_controller.rb
@@ -8,7 +8,7 @@ class EventAttendeesController < ApplicationController
 
   # GET /event_attendees or /event_attendees.json
   def index
-    @event_attendees = EventAttendee.where(profile_id: current_user.profile.id)
+    @event_attendees = EventAttendee.where(profile: current_user.profile)
   end
 
   # GET /event_attendees/1 or /event_attendees/1.json

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,16 +8,16 @@ class EventsController < ApplicationController
   # GET /events or /events.json
   def index
     @events = Event.ongoing_or_upcoming
+    @friends_attending_count = {}
+    @events.each do |event|
+      @friends_attending_count[event.id] = EventAttendee.friends_attending(event:, profile: current_profile).count
+    end
   end
 
   # GET /events/1 or /events/1.json
   def show
     return unless current_profile
-    @event_attendees = EventAttendee
-                       .where(event_id: @event.id)
-                       .joins(:profile)
-                       .where(profiles:
-        { id: current_profile.friends.select(:id) })
+    @event_attendees = EventAttendee.friends_attending(event: @event, profile: current_profile)
   end
 
   # GET /events/new

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,6 +8,7 @@ class EventsController < ApplicationController
   # GET /events or /events.json
   def index
     @events = Event.ongoing_or_upcoming
+    return unless current_profile
     @friends_attending_count = {}
     @events.each do |event|
       @friends_attending_count[event.id] = EventAttendee.friends_attending(event:, profile: current_profile).count

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -2,8 +2,8 @@
 
 # Helper methods for managing Profiles
 module ProfilesHelper
-  def profile_picture(email)
+  def profile_picture(email, size: 80)
     "https://gravatar.com/avatar/#{Digest::SHA2.hexdigest(email.downcase.strip)}" \
-      "?s=80&d=retro&r=pg"
+      "?s=#{size}&d=retro&r=pg"
   end
 end

--- a/app/models/event_attendee.rb
+++ b/app/models/event_attendee.rb
@@ -4,4 +4,8 @@
 class EventAttendee < ApplicationRecord
   belongs_to :profile
   belongs_to :event
+
+  def self.friends_attending(event:, profile:)
+    EventAttendee.where(event:, profile: profile.friends).includes(:profile, :event)
+  end
 end

--- a/app/views/event_attendees/_list.html.erb
+++ b/app/views/event_attendees/_list.html.erb
@@ -2,7 +2,10 @@
   <h4><%= t(".buddies_attending", count: event_attendees.count) %></h4>
   <ul>
     <% event_attendees.each do |event_attendee| %>
-      <li><%= link_to event_attendee.profile %></li>
+      <li>
+        <img src="<%= profile_picture(event_attendee.profile.email, size: 16) %>" alt="Profile pic" />
+        <%= link_to event_attendee.profile %>
+      </li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/event_attendees/index.html.erb
+++ b/app/views/event_attendees/index.html.erb
@@ -13,8 +13,8 @@
     <tbody>
       <% @event_attendees.each do |event_attendee| %>
         <tr>
-          <td><%= event_attendee.profile.name %></td>
-          <td><%= event_attendee.event.name %></td>
+          <td><%= link_to event_attendee.profile.name, event_attendee.profile %></td>
+          <td><%= link_to event_attendee.event.name, event_attendee.event %></td>
           <td>
             <%= buttons(event_attendee, include_show: true) %>
           </td>

--- a/app/views/events/_list.html.erb
+++ b/app/views/events/_list.html.erb
@@ -3,6 +3,9 @@
     <tr>
       <th>Name</th>
       <th class="is-hidden-mobile">Description</th>
+      <% if @friends_attending_count %>
+        <th colspan="3"></th>
+      <% end %>
       <th colspan="2"></th>
     </tr>
   </thead>
@@ -12,6 +15,9 @@
       <tr>
         <td><%= link_to event %></td>
         <td class="is-hidden-mobile"><%= kramdown_pure_text(event.description) %></td>
+        <% if @friends_attending_count %>
+          <td><%= "#{@friends_attending_count[event.id]} Friends Attending." %></td>
+        <% end %>
         <td><%= date_range(event) %></td>
         <td><%= buttons(event) %></td>
       </tr>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="section container">
   <h1 class="title">Events</h1>
   <%= render 'list', events: @events %>
   <%= link_to 'New Event', new_event_path, class: "button is-primary" if policy(:event).new? %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,39 +1,41 @@
-<div class="container">
-  <div class="columns">
-    <div class="column">
-      <h1 class="title"><%= @event.name %></h1>
-      <p role="doc-subtitle" class="subtitle"><%= date_range(@event) %></p>
-      <p>
-        <%= kramdown(@event.description) %>
-      </p>
+<div class="section">
+  <div class="container">
+    <div class="columns">
+      <div class="column">
+        <h1 class="title"><%= @event.name %></h1>
+        <p role="doc-subtitle" class="subtitle"><%= date_range(@event) %></p>
+        <p>
+          <%= kramdown(@event.description) %>
+        </p>
 
-      <p>
-        <%= buttons(@event, include_nav: true) %>
-      </p>
-    </div>
-
-    <div class="column is-one-quarter">
-      <div class="mb-3">
-        <% if current_user&.profile&.attending? @event %>
-          <%= button_to "Not Attending",
-          { controller: :event_attendees,
-          action: :destroy,
-          id: current_user&.profile&.event_attendee(@event)&.first&.id },
-          method: :delete,
-          class: "button is-danger" %>
-        <% elsif current_user %>
-          <%= button_to "Attend",
-            event_attendees_path(
-              event_attendee: {
-                                profile_id: current_user.profile&.id,
-                                event_id: @event.id
-                            }
-          ),
-          action: "create",
-          class: "button is-primary" %>
-        <% end %>
+        <p>
+          <%= buttons(@event, include_nav: true) %>
+        </p>
       </div>
-      <%= render "event_attendees/list", event_attendees: @event_attendees %>
+
+      <div class="column is-one-quarter">
+        <div class="mb-3">
+          <% if current_user&.profile&.attending? @event %>
+            <%= button_to "Not Attending",
+            { controller: :event_attendees,
+            action: :destroy,
+            id: current_user&.profile&.event_attendee(@event)&.first&.id },
+            method: :delete,
+            class: "button is-danger" %>
+          <% elsif current_user %>
+            <%= button_to "Attend",
+              event_attendees_path(
+                event_attendee: {
+                                  profile_id: current_user.profile&.id,
+                                  event_id: @event.id
+                              }
+            ),
+            action: "create",
+            class: "button is-primary" %>
+          <% end %>
+        </div>
+        <%= render "event_attendees/list", event_attendees: @event_attendees %>
+      </div>
     </div>
   </div>
 </div>

--- a/spec/models/event_attendee_spec.rb
+++ b/spec/models/event_attendee_spec.rb
@@ -6,4 +6,28 @@ RSpec.describe EventAttendee do
   let(:event_attendee) { create :event_attendee }
 
   it { expect(event_attendee).to be_valid }
+
+  describe ".friends_attending" do
+    subject { described_class.friends_attending(event:, profile:) }
+
+    let(:profile) { create :profile }
+    let(:event) { create :event }
+
+    it "returns nothing with no events" do
+      expect(subject.count).to eq 0
+    end
+
+    context "when attending events" do
+      let!(:event_attendee) { create :event_attendee, event:, profile: }
+
+      it { expect(subject.count).to eq 0 }
+
+      context "with friends attending" do
+        let(:friendship) { create :friendship, buddy: profile, status: :accepted }
+        let!(:friend_attendee) { create :event_attendee, event:, profile: friendship.friend }
+
+        it { expect(subject).to include(friend_attendee) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of Feature or Issue

Add a new method to event attendee to make it easier to find friends who are also attending an event.
Update the appearance of /Events for aesthetic purposes, and to share the number of friends attending.

TODO:
Currently has an expensive N+1 query on the /events page
/events page is pretty ugly too - new issue created for that

## Checklist
- [ ] Added/changed specs for the changes made
- [ ] Is the linting build successful?
- [ ] Is the test build successful?

## User-Facing Changes
![events page with a new column that has friends attending](https://github.com/ChaelCodes/HallwayTracks/assets/8124558/dcc51fb2-d51e-4e7c-b7f5-a60c6437856c)

![attendees have small profile pictures now](https://github.com/ChaelCodes/HallwayTracks/assets/8124558/b9e2ea4a-41eb-4d84-b291-355ad1747e91)


