### PR TITLE
Friend Requests can be made to Friends/Myself Visibility Profiles

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ Metrics/BlockLength:
   Exclude:
     - "config/environments/**/*"
     - "spec/**/*"
+    - "db/seeds/**/*"
 
 Metrics/MethodLength:
   Exclude:

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -13,7 +13,7 @@ class ProfilesController < ApplicationController
 
   # GET /profiles/1 or /profiles/1.json
   def show
-    @events = @profile.events
+    @events = @profile.events if policy(@profile).show_details?
   end
 
   # GET /profiles/new

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -2,8 +2,19 @@
 
 # Helper methods for managing Profiles
 module ProfilesHelper
+  UNAUTHORIZED_PROFILE_MESSAGES = {
+    everyone: "",
+    authenticated: "You must be logged in, and you email confirmed to view this profile.",
+    friends: "You must be friends to view this profile.",
+    myself: "This profile is not visible to others at this time."
+  }.freeze
+
   def profile_picture(email, size: 80)
     "https://gravatar.com/avatar/#{Digest::SHA2.hexdigest(email.downcase.strip)}" \
       "?s=#{size}&d=retro&r=pg"
+  end
+
+  def unauthorized_message(profile)
+    UNAUTHORIZED_PROFILE_MESSAGES.with_indifferent_access[profile.visibility]
   end
 end

--- a/app/policies/profile_policy.rb
+++ b/app/policies/profile_policy.rb
@@ -13,14 +13,21 @@ class ProfilePolicy < ApplicationPolicy
     confirmed_user?
   end
 
-  # This method controls whether a user can view a profile.
+  # Whether the user can view the Profile's Handle, Bio, and Avatar.
+  def show?
+    return true if mine? || admin? || profile.visible_to_everyone?
+    confirmed_user?
+  end
+
+  # This method controls whether a user can view a profile's details.
+  # The details include the bio and event attendance.
   # Admins can always view profiles. Users can view their own profiles.
   # Profiles can set their own visibility.
   # * Everyone - anyone can view
   # * Authenticated - only logged in, and confirmed users can view
   # * Friends - only accepted friends can view
   # * Myself - only the user can view - NOT EVEN EXISTING FRIENDS!
-  def show?
+  def show_details?
     return true if mine? || admin? || profile.visible_to_everyone?
     return confirmed_user? if profile.visible_to_authenticated?
     current_profile&.friends_with? profile if profile.visible_to_friends?

--- a/app/views/events/_list.html.erb
+++ b/app/views/events/_list.html.erb
@@ -1,26 +1,30 @@
-<table class="table">
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th class="is-hidden-mobile">Description</th>
-      <% if @friends_attending_count %>
-        <th colspan="3"></th>
-      <% end %>
-      <th colspan="2"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% events.each do |event| %>
+<% unless events&.any? %>
+  <p>There are no events to display.</p>
+<% else %>
+  <table class="table">
+    <thead>
       <tr>
-        <td><%= link_to event %></td>
-        <td class="is-hidden-mobile"><%= kramdown_pure_text(event.description) %></td>
+        <th>Name</th>
+        <th class="is-hidden-mobile">Description</th>
         <% if @friends_attending_count %>
-          <td><%= "#{@friends_attending_count[event.id]} Friends Attending." %></td>
+          <th colspan="3"></th>
         <% end %>
-        <td><%= date_range(event) %></td>
-        <td><%= buttons(event) %></td>
+        <th colspan="2"></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+
+    <tbody>
+      <% events.each do |event| %>
+        <tr>
+          <td><%= link_to event %></td>
+          <td class="is-hidden-mobile"><%= kramdown_pure_text(event.description) %></td>
+          <% if @friends_attending_count %>
+            <td><%= "#{@friends_attending_count[event.id]} Friends Attending." %></td>
+          <% end %>
+          <td><%= date_range(event) %></td>
+          <td><%= buttons(event) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -13,11 +13,13 @@
       </div>
     </div>
     <div class="block">
-      <p><%= @profile.bio %></p>
+      <p>
+        <%= policy(@profile).show_details? ? @profile.bio : unauthorized_message(@profile) %>
+      </p>
     </div>
   </div>
 </div>
-<% if @profile.events.present? %>
+<% if policy(@profile).show_details? %>
   <div class="section">
     <div class="container">
       <div class="block">

--- a/db/seeds/development/profiles.seeds.rb
+++ b/db/seeds/development/profiles.seeds.rb
@@ -1,15 +1,47 @@
 # frozen_string_literal: true
 
 after "development:users" do
-  chael = User.find_by(name: "Chael")
-  john = User.find_by(name: "John")
+  chael = User.find_by!(email: "admin@example.com")
+  john = User.find_by!(email: "john@example.com")
+  everyone = User.find_by!(email: "everyone@example.com")
+  authenticated = User.find_by!(email: "authenticated@example.com")
+  friends = User.find_by!(email: "friends@example.com")
+  myself = User.find_by!(email: "myself@example.com")
 
   profiles = [
     { name: "Chael's Profile", handle: "chaels_handle", user_id: chael.id },
-    { name: "John's Profile", handle: "john_handle", user_id: john.id }
+    { name: "John's Profile", handle: "john_handle", user_id: john.id },
+    {
+      name: "Everyone Visibility",
+      handle: "everyone_handle",
+      bio: "This is an Everyone Visibility Profile",
+      user_id: everyone.id,
+      visibility: :everyone
+    },
+    {
+      name: "Authenticated Visibility",
+      handle: "authenticated_handle",
+      bio: "This is an Authenticated Visibility Profile",
+      user_id: authenticated.id,
+      visibility: :authenticated
+    },
+    {
+      name: "Friends Visibility",
+      handle: "friends_handle",
+      bio: "This is an Friends Visibility Profile",
+      user_id: friends.id,
+      visibility: :friends
+    },
+    {
+      name: "Myself Visibility",
+      handle: "myself_handle",
+      bio: "This is an Myself Visibility Profile",
+      user_id: myself.id,
+      visibility: :myself
+    }
   ]
 
   profiles.each do |profile|
-    Profile.find_or_create_by(profile)
+    Profile.find_or_initialize_by(handle: profile[:handle]).update(profile)
   end
 end

--- a/db/seeds/development/users.seeds.rb
+++ b/db/seeds/development/users.seeds.rb
@@ -12,6 +12,18 @@ users = [
     email: "john@example.com",
     name: "John",
     admin: false
+  },
+  {
+    email: "everyone@example.com"
+  },
+  {
+    email: "authenticated@example.com"
+  },
+  {
+    email: "friends@example.com"
+  },
+  {
+    email: "myself@example.com"
   }
 ]
 

--- a/spec/helpers/profiles_helper_spec.rb
+++ b/spec/helpers/profiles_helper_spec.rb
@@ -12,4 +12,31 @@ RSpec.describe ProfilesHelper do
       is_expected.to eq "https://gravatar.com/avatar/973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b?s=80&d=retro&r=pg"
     end
   end
+
+  describe "#unauthorized_message" do
+    subject { helper.unauthorized_message(profile) }
+
+    let(:profile) { build :profile, visibility: }
+    let(:visibility) { :everyone }
+
+    it { is_expected.to eq "" }
+
+    context "when visibility is authorized" do
+      let(:visibility) { :authenticated }
+
+      it { is_expected.to eq "You must be logged in, and you email confirmed to view this profile." }
+    end
+
+    context "when visibility is friends" do
+      let(:visibility) { :friends }
+
+      it { is_expected.to eq "You must be friends to view this profile." }
+    end
+
+    context "when visibility is myself" do
+      let(:visibility) { :myself }
+
+      it { is_expected.to eq "This profile is not visible to others at this time." }
+    end
+  end
 end


### PR DESCRIPTION
## Description of Feature or Issue
closes #169 

Originally you could not make friend requests to profiles who used friends and myself visibility. These profiles would redirect, and the only page you can submit friend requests on is the profile page.

This change will make profiles visible to authenticated users - those who've confirmed their email and are logged in. Only the avatar, name, and handle will be visible on the profile. The bio and events are still restricted.

We don't want to give unauthorized users visibility, because:
A - they can't befriend profiles
B - this prevents robots from viewing profiles
C - this closes a loophole where blocked profiles can just log out

This is a good balance between protecting the privacy of the profile, and making it possible to befriend those profiles.

## Checklist
- [x] Added/changed specs for the changes made
- [ ] Is the linting build successful?
- [ ] Is the test build successful?

## User-Facing Changes

![A friends visibility profile as a non-friend. The "request friend" button is visible and a message "You must be friends to view this profile." is displayed.](https://github.com/ChaelCodes/HallwayTracks/assets/8124558/9f024c7f-8745-4e74-87fa-055d88b9378e)

![A myself visibility profile. The "request friend" button is visible and a message "This profile is not visible to others at this time." is displayed.](https://github.com/ChaelCodes/HallwayTracks/assets/8124558/4f58341f-c73d-4320-bcfa-73fb9cf187db)
